### PR TITLE
Set up the FlexDaemonsets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Start with a minimal Go image
+FROM golang:1.22-alpine as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+COPY pkg/apis/ pkg/apis/ # Corrected path for apis
+
+# Build
+# CGO_ENABLED=0 to build a statically linked executable
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/manager/main.go
+
+# Use a distroless image for the final stage for a smaller security footprint
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER nonroot:nonroot
+
+ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,132 @@
+# Image and controller name settings
+IMG ?= flexdaemonsets-webhook:latest
+CONTROLLER_IMG ?= $(IMG) # Keeping it simple, IMG is the main image we build
+WEBHOOK_NAMESPACE ?= flexdaemonsets-system
+CERT_DIR ?= ./_certs # Directory to store generated certs locally
+
+# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
+GOBIN ?= $(shell go env GOBIN)
+ifeq ($(GOBIN),)
+GOBIN = $(shell go env GOPATH)/bin
+endif
+
+# Setting SHELL to bash allows bash commands to be used in recipes.
+SHELL = /usr/bin/env bash
+
+.PHONY: all
+all: build
+
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire Makefile.
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Development
+
+.PHONY: manager
+manager: ## Build the manager binary.
+	@echo "Building manager binary..."
+	CGO_ENABLED=0 go build -o bin/manager cmd/manager/main.go
+
+.PHONY: run
+run: manager ## Run the manager locally (requires certs in CERT_DIR).
+	@echo "Running manager locally..."
+	@echo "Make sure you have TLS certificates in $(CERT_DIR) or specify a different --cert-dir."
+	./bin/manager --cert-dir=$(CERT_DIR) --metrics-bind-address=localhost:8080 --health-probe-bind-address=localhost:8081
+
+.PHONY: generate-certs
+generate-certs: ## Generate self-signed TLS certificates for local testing.
+	@echo "Generating self-signed TLS certificates in $(CERT_DIR)..."
+	@mkdir -p $(CERT_DIR)
+	@openssl genrsa -out $(CERT_DIR)/ca.key 2048
+	@openssl req -x509 -new -nodes -key $(CERT_DIR)/ca.key -subj "/CN=flexdaemonsets.xai" -days 365 -out $(CERT_DIR)/ca.crt
+	@openssl genrsa -out $(CERT_DIR)/tls.key 2048
+	@openssl req -new -key $(CERT_DIR)/tls.key -subj "/CN=flexdaemonsets-webhook-svc.$(WEBHOOK_NAMESPACE).svc" -out $(CERT_DIR)/tls.csr
+	@openssl x509 -req -in $(CERT_DIR)/tls.csr -CA $(CERT_DIR)/ca.crt -CAkey $(CERT_DIR)/ca.key -CAcreateserial -out $(CERT_DIR)/tls.crt -days 365 -sha256 -extfile <(printf "subjectAltName=DNS:flexdaemonsets-webhook-svc.$(WEBHOOK_NAMESPACE).svc,DNS:flexdaemonsets-webhook-svc.$(WEBHOOK_NAMESPACE).svc.cluster.local")
+	@echo "Certificates generated in $(CERT_DIR): ca.crt, tls.crt, tls.key"
+	@echo "To use them, create a secret e.g.:"
+	@echo "  kubectl create secret tls flexdaemonsets-webhook-tls \"
+	@echo "    --cert=$(CERT_DIR)/tls.crt \"
+	@echo "    --key=$(CERT_DIR)/tls.key \"
+	@echo "    -n $(WEBHOOK_NAMESPACE)"
+
+
+##@ Build
+
+.PHONY: build
+build: manager ## Build manager binary.
+	@echo "Manager binary built at bin/manager."
+
+# Ensure the image name is defined
+ifndef IMAGE_TAG_BASE
+	IMAGE_TAG_BASE = prakarshmodificationusg/flexdaemonsets-webhook
+endif
+IMG ?= ${IMAGE_TAG_BASE}:latest
+
+.PHONY: docker-build
+docker-build: ## Build docker image with the manager.
+	@echo "Building Docker image $(IMG)..."
+	docker build -t $(IMG) .
+
+.PHONY: docker-push
+docker-push: ## Push docker image.
+	@echo "Pushing Docker image $(IMG)..."
+	docker push $(IMG)
+
+
+##@ Deployment (requires kubectl configured for a cluster)
+
+# KUSTOMIZE ?= $(GOBIN)/kustomize
+KUBECTL ?= kubectl
+
+.PHONY: deploy-manifests
+deploy-manifests: ## Apply all manifests in the manifests directory.
+	@echo "Applying manifests from ./manifests directory..."
+	$(KUBECTL) apply -f ./manifests/
+	@echo "Waiting for CRD to be established..."
+	@while ! $(KUBECTL) get crd flexdaemonsettemplates.flexdaemonsets.xai > /dev/null 2>&1; do \
+	  echo "  Waiting for CRD flexdaemonsettemplates.flexdaemonsets.xai..."; \
+	  sleep 1; \
+	done
+	@echo "CRD flexdaemonsettemplates.flexdaemonsets.xai is established."
+	@echo "Important: Ensure the 'caBundle' in 'manifests/webhook.yaml' is correctly set or injected (e.g., by cert-manager)."
+	@echo "If using self-signed certs (via make generate-certs), update caBundle with content of $(CERT_DIR)/ca.crt (base64 encoded)."
+	@echo "You may also need to restart existing pods if the webhook is re-deployed with changes that affect them."
+
+.PHONY: deploy
+deploy: manager docker-build deploy-manifests ## Build, Docker build, and deploy all manifests.
+	@echo "Deployment initiated. Use 'make docker-push' if you need to push the image to a registry."
+	@echo "To complete deployment if not using cert-manager for caBundle injection:"
+	@echo "1. Ensure your Docker image $(IMG) is available to your cluster (e.g., pushed to a registry)."
+	@echo "2. Create the TLS secret 'flexdaemonsets-webhook-tls' in namespace '$(WEBHOOK_NAMESPACE)' using your generated certs (see 'make generate-certs' output)."
+	@echo "3. Base64 encode $(CERT_DIR)/ca.crt and update 'caBundle' in 'manifests/webhook.yaml'."
+	@echo "4. Re-apply 'manifests/webhook.yaml': $(KUBECTL) apply -f manifests/webhook.yaml"
+	@echo "5. Update the image in 'manifests/deployment.yaml' to $(IMG) if it's not already set, then $(KUBECTL) apply -f manifests/deployment.yaml"
+
+
+.PHONY: undeploy-manifests
+undeploy-manifests: ## Delete all manifests in the manifests directory.
+	@echo "Deleting manifests from ./manifests directory..."
+	$(KUBECTL) delete -f ./manifests/ --ignore-not-found=true
+
+.PHONY: undeploy
+undeploy: undeploy-manifests ## Delete all deployed resources.
+	@echo "Undeployment complete."
+	@echo "Note: This does not delete the CRD instances, only the definition and webhook components."
+	@echo "To delete the CRD (and all its custom resources): $(KUBECTL) delete crd flexdaemonsettemplates.flexdaemonsets.xai"
+
+.PHONY: clean-certs
+clean-certs: ## Remove locally generated TLS certificates.
+	@echo "Removing local certificates from $(CERT_DIR)..."
+	@rm -rf $(CERT_DIR)
+
+.PHONY: clean
+clean: clean-certs ## Remove build artifacts and local certificates.
+	@echo "Cleaning up build artifacts..."
+	@rm -f bin/manager
+	@echo "Cleanup complete."

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# flex-daemosets-k8s
+# FlexDaemonsets
+
+## Overview
+
+FlexDaemonsets enhances resource allocation for DaemonSets in heterogeneous Kubernetes clusters. It allows defining resource requests and limits for DaemonSet pods as a percentage of each node's total allocatable resources, rather than using fixed absolute values. This ensures efficient and scalable resource utilization, especially in clusters with nodes of varying sizes (e.g., from 4-core to 64-core VMs).
+
+The solution uses:
+- A **Custom Resource Definition (CRD)** named `FlexDaemonsetTemplate` to define percentage-based resource allocation templates.
+- An **annotation** on DaemonSets (`flexdaemonsets.xai/resource-template: <template-name>`) to opt-in for this feature.
+- A **mutating webhook** that intercepts pod creation for annotated DaemonSets, calculates the appropriate resources based on the node's capacity and the template, and injects these values into the pod specification.
+
+## Project Structure
+
+- `cmd/manager/main.go`: Main entry point for the webhook server.
+- `pkg/apis/`: Contains the API type definitions for `FlexDaemonsetTemplate` (e.g., `pkg/apis/flexdaemonsets/v1alpha1/types.go`).
+- `pkg/webhook/`: Contains the core mutating webhook logic.
+- `pkg/utils/`: Utility functions, including resource calculation.
+- `manifests/`: Kubernetes manifests for CRD, RBAC, webhook configuration, deployment, and samples.
+- `Dockerfile`: For building the webhook server container image.
+- `Makefile`: For build, Docker, and deployment automation.
+
+## Getting Started
+
+(Instructions will be added here for building, deploying, and using FlexDaemonsets)
+
+## Prerequisites
+
+- Go (version 1.22 or higher)
+- Docker (for building images)
+- kubectl
+- A Kubernetes cluster (v1.21+)
+
+## (Development) Building and Running Locally
+
+(Instructions to be added)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -1,1 +1,108 @@
+package main
 
+import (
+	"flag"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // For GCP auth
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/webhook" // Ensure webhook is imported if directly used, though often implicitly handled by manager
+
+	flexdaemonsetsv1alpha1 "github.com/prakarsh-dt/FlexDaemonsets/pkg/apis/flexdaemonsets/v1alpha1"
+	flexdaemonsetwebhook "github.com/prakarsh-dt/FlexDaemonsets/pkg/webhook" // Import the webhook package
+	// +kubebuilder:scaffold:imports
+)
+
+var (
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+func init() {
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = flexdaemonsetsv1alpha1.AddToScheme(scheme)
+	// +kubebuilder:scaffold:scheme
+}
+
+func main() {
+	var metricsAddr string
+	var enableLeaderElection bool
+	var probeAddr string
+	var certDir string // Added variable for cert directory
+
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.")
+	// Added flag for cert directory. The controller-runtime manager will automatically use this directory
+	// to find tls.crt and tls.key files for the webhook server.
+	flag.StringVar(&certDir, "cert-dir", "/tmp/k8s-webhook-server/serving-certs", "Directory where the TLS certs (tls.crt, tls.key) are located. Defaults to /tmp/k8s-webhook-server/serving-certs if not provided, or if empty.")
+
+	opts := zap.Options{
+		Development: true,
+	}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	setupLog.Info("Initializing manager", "certDir", certDir)
+	// The manager's webhook server will be started locally on Port (default 9443 for controller-runtime v0.11+)
+	// and will use the CertDir to serve TLS.
+	// Certificates (tls.crt and tls.key) must be present in CertDir.
+	// For local development, these can be self-signed certificates.
+	// For example, using openssl:
+	// openssl genrsa -out tls.key 2048
+	// openssl req -new -key tls.key -out tls.csr (fill prompts)
+	// openssl x509 -req -days 365 -in tls.csr -signkey tls.key -out tls.crt
+	// Then place tls.crt and tls.key into the certDir.
+	// In a cluster, cert-manager is a common way to provision and manage TLS certificates for webhooks.
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                 scheme,
+		MetricsBindAddress:     metricsAddr,
+		Port:                   9443, // Default webhook server port
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "flexdaemonsets.xai",
+		CertDir:                certDir, // Pass the certDir to the manager
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	// Setup webhooks
+	setupLog.Info("Setting up webhook server and registering webhooks")
+	// Get the webhook server from the manager.
+	// The server is already configured by the manager options (Port, CertDir).
+	hookServer := mgr.GetWebhookServer()
+
+	// Register the PodMutator webhook. The path here is important and should match
+	// the MutatingWebhookConfiguration in your deployment manifests.
+	hookServer.Register(
+		"/mutate-v1-pod",
+		&webhook.Admission{Handler: &flexdaemonsetwebhook.PodMutator{Client: mgr.GetClient()}},
+	)
+
+	// +kubebuilder:scaffold:builder
+
+	// Add health and readiness checks. The webhook server's StartedChecker can be used.
+	if err := mgr.AddHealthzCheck("healthz", hookServer.StartedChecker()); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", hookServer.StartedChecker()); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+
+	setupLog.Info("Starting manager. Webhook server will listen on port set in manager options (default 9443) for HTTPS requests.")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flexdaemonsets-webhook-deployment
+  namespace: flexdaemonsets-system
+  labels:
+    app.kubernetes.io/name: flexdaemonsets
+    app.kubernetes.io/component: webhook-server
+spec:
+  replicas: 2 # Recommended for HA
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: flexdaemonsets-webhook
+      app.kubernetes.io/component: webhook-pod
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: flexdaemonsets-webhook
+        app.kubernetes.io/component: webhook-pod
+    spec:
+      serviceAccountName: flexdaemonsets-webhook-sa
+      containers:
+      - name: webhook-server
+        image: prakarshmodificacióndev/flexdaemonsets-webhook:latest # Placeholder image name, replace with actual
+        imagePullPolicy: IfNotPresent # Or Always, depending on your image update strategy
+        args:
+          - "--cert-dir=/etc/webhook/certs" # Path where certs are mounted
+          - "--metrics-bind-address=:8080" # Optional: if you want to expose metrics
+          - "--health-probe-bind-address=:8081" # For health/readiness probes
+        ports:
+        - name: webhook-https
+          containerPort: 9443 # Port the webhook server listens on (mgr default)
+          protocol: TCP
+        - name: metrics # Optional metrics port
+          containerPort: 8080
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081 # health-probe-bind-address
+            scheme: HTTP # Probes are usually HTTP, even if service is HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081 # health-probe-bind-address
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /etc/webhook/certs # Mount path for certs
+          readOnly: true
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: flexdaemonsets-webhook-tls # Name of the Secret containing tls.crt and tls.key
+          # This secret needs to be created (e.g., by cert-manager or manually)
+          # Example for manual creation:
+          # kubectl create secret tls flexdaemonsets-webhook-tls \
+          #   --cert=path/to/tls.crt \
+          #   --key=path/to/tls.key \
+          #   -n flexdaemonsets-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flexdaemonsets-webhook-svc
+  namespace: flexdaemonsets-system
+  labels:
+    app.kubernetes.io/name: flexdaemonsets
+    app.kubernetes.io/component: webhook-service
+spec:
+  selector:
+    app.kubernetes.io/name: flexdaemonsets-webhook # Should match labels on the Pods
+    app.kubernetes.io/component: webhook-pod
+  ports:
+  - name: https
+    port: 443 # Port the K8s API server will call (as defined in MutatingWebhookConfiguration)
+    targetPort: webhook-https # Named port on the pod (9443)
+    protocol: TCP

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flexdaemonsets-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flexdaemonsets-webhook-sa
+  namespace: flexdaemonsets-system # Deploy webhook components in their own namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flexdaemonsets-webhook-role
+rules:
+- apiGroups: [""] # core API group
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["flexdaemonsets.xai"]
+  resources: ["flexdaemonsettemplates"]
+  verbs: ["get", "list", "watch"]
+# No specific permissions needed for "pods" here for the webhook to read the incoming pod in AdmissionReview.
+# The ability to patch pods is granted by the MutatingWebhookConfiguration.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flexdaemonsets-webhook-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flexdaemonsets-webhook-role
+subjects:
+- kind: ServiceAccount
+  name: flexdaemonsets-webhook-sa
+  namespace: flexdaemonsets-system

--- a/manifests/sample-daemonset.yaml
+++ b/manifests/sample-daemonset.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sample-flex-daemonset
+  namespace: default # Or any namespace where you want to test
+  labels:
+    app: sample-flex-ds
+spec:
+  selector:
+    matchLabels:
+      app: sample-flex-ds
+  template:
+    metadata:
+      labels:
+        app: sample-flex-ds
+      annotations:
+        # This annotation tells our webhook to process pods from this DaemonSet
+        flexdaemonsets.xai/resource-template: "default-resource-percentages" # Assuming 'default-resource-percentages' FlexDaemonsetTemplate exists
+    spec:
+      # nodeSelector: {} # Optional: Target specific nodes
+      # tolerations: [] # Optional: For scheduling on tainted nodes
+      containers:
+      - name: my-sample-container
+        image: nginx:latest # A simple image for demonstration
+        # Resources will be injected by the FlexDaemonsets webhook
+        # You can leave requests/limits empty or provide defaults that will be overwritten
+        resources:
+          requests:
+            cpu: "50m" # These will be overridden if webhook runs
+            memory: "32Mi"
+          limits:
+            cpu: "100m"
+            memory: "64Mi"
+      # Example of a FlexDaemonsetTemplate (ensure this or a similar CR is applied to the cluster)
+      # You already have manifests/sample-flexdaemonsettemplate.yaml
+      # ---
+      # apiVersion: flexdaemonsets.xai/v1alpha1
+      # kind: FlexDaemonsetTemplate
+      # metadata:
+      #   name: default-resource-percentages
+      # spec:
+      #   cpuPercentage: 10
+      #   memoryPercentage: 15
+      #   storagePercentage: 5
+      #   minCPU: "100m"
+      #   minMemory: "128Mi"
+      #   minStorage: "1Gi"

--- a/manifests/webhook.yaml
+++ b/manifests/webhook.yaml
@@ -1,0 +1,32 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: flexdaemonsets-mutating-webhook-config
+  labels:
+    app.kubernetes.io/name: flexdaemonsets
+    app.kubernetes.io/component: webhook
+webhooks:
+- name: flexdaemonsets.xai.webhook # Make it fully qualified and descriptive
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+  failurePolicy: Fail # Or Ignore, depending on desired behavior on error
+  clientConfig:
+    service:
+      name: flexdaemonsets-webhook-svc
+      namespace: flexdaemonsets-system
+      path: "/mutate-v1-pod"
+      port: 443 # Port on the service that maps to targetPort 9443 on the pod
+    # caBundle must be a base64 encoded CA certificate that signed the webhook's serving certificate.
+    # For cert-manager, this is typically injected automatically.
+    # For manual setup, you'll need to generate this and place it here.
+    # Placeholder: "Cg==" is a base64 encoded newline. Replace with actual CA bundle.
+    caBundle: "Cg==" 
+  rules:
+  - operations: ["CREATE"]
+    apiGroups: [""] # core API Group
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    # scope: "Namespaced" # Pods are namespaced
+  # objectSelector: {} # Optional: To narrow down which pods are sent. We filter in webhook logic.
+  # namespaceSelector: {} # Optional: To only intercept pods in specific namespaces.
+  timeoutSeconds: 5 # How long the API server should wait for the webhook to respond

--- a/pkg/utils/resources.go
+++ b/pkg/utils/resources.go
@@ -1,0 +1,170 @@
+package utils
+
+import (
+	"fmt"
+	// "math" // Not strictly required for math.Max as we are using Quantity.Cmp
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource" // Required for resource.Quantity
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	flexdaemonsetsv1alpha1 "github.com/prakarsh-dt/FlexDaemonsets/pkg/apis/flexdaemonsets/v1alpha1"
+)
+
+var log = ctrl.Log.WithName("utils").WithName("resources")
+
+// CalculatePodResources calculates the desired resource requests and limits for a pod's containers
+// based on the FlexDaemonsetTemplate and the node's allocatable resources.
+// For now, we'll set requests and limits to be the same, as is common for critical workloads like DaemonSets.
+func CalculatePodResources(
+	templateSpec *flexdaemonsetsv1alpha1.FlexDaemonsetTemplateSpec,
+	nodeAllocatable corev1.ResourceList,
+) (corev1.ResourceList, error) {
+
+	calculatedResources := corev1.ResourceList{}
+	var err error
+
+	// Calculate CPU
+	cpuAllocatable, ok := nodeAllocatable[corev1.ResourceCPU]
+	if !ok {
+		log.Info("Node has no allocatable CPU information. Cannot calculate CPU percentage.")
+		// Fallback to MinCPU if specified, otherwise, no CPU is requested.
+		if templateSpec.MinCPU != "" {
+			parsedMinCPU, parseErr := resource.ParseQuantity(templateSpec.MinCPU)
+			if parseErr != nil {
+				log.Error(parseErr, "Failed to parse MinCPU", "MinCPU", templateSpec.MinCPU)
+				return nil, fmt.Errorf("failed to parse MinCPU '%s': %w", templateSpec.MinCPU, parseErr)
+			}
+			if parsedMinCPU.MilliValue() > 0 { // Only add if MinCPU itself is > 0
+				calculatedResources[corev1.ResourceCPU] = parsedMinCPU
+			} else {
+				log.Info("MinCPU is specified but parses to zero or less, requesting no CPU.", "MinCPU", templateSpec.MinCPU)
+			}
+		} else {
+			log.Info("Node has no allocatable CPU and no MinCPU specified, requesting no CPU.")
+		}
+	} else {
+		// Calculate CPU based on percentage
+		cpuPercentageValue := float64(cpuAllocatable.MilliValue()) * (float64(templateSpec.CPUPercentage) / 100.0)
+		calculatedCPU := resource.NewMilliQuantity(int64(cpuPercentageValue), resource.DecimalSI)
+		
+		minCPUQuantitySet := false
+		var minCPUQuantity resource.Quantity
+		if templateSpec.MinCPU != "" {
+			var parseErr error
+			minCPUQuantity, parseErr = resource.ParseQuantity(templateSpec.MinCPU)
+			if parseErr != nil {
+				log.Error(parseErr, "Failed to parse MinCPU", "MinCPU", templateSpec.MinCPU)
+				return nil, fmt.Errorf("failed to parse MinCPU '%s': %w", templateSpec.MinCPU, parseErr)
+			}
+			minCPUQuantitySet = true
+		}
+
+		// If MinCPU is specified and calculated CPU is less than MinCPU, use MinCPU.
+		if minCPUQuantitySet && calculatedCPU.Cmp(minCPUQuantity) < 0 {
+			log.Info("Calculated CPU is less than MinCPU, using MinCPU", "calculatedCPU", calculatedCPU.String(), "minCPU", minCPUQuantity.String())
+			calculatedCPU = &minCPUQuantity
+		}
+		
+		// Only add CPU to resources if it's greater than 0.
+		if calculatedCPU.MilliValue() > 0 {
+		    calculatedResources[corev1.ResourceCPU] = *calculatedCPU
+		} else {
+		    log.Info("Calculated CPU (after considering MinCPU if any) is zero or less. Requesting no CPU.", "finalCalculatedCPU", calculatedCPU.String())
+		}
+	}
+
+	// Calculate Memory
+	memoryAllocatable, ok := nodeAllocatable[corev1.ResourceMemory]
+	if !ok {
+		log.Info("Node has no allocatable Memory information. Cannot calculate Memory percentage.")
+		if templateSpec.MinMemory != "" {
+			parsedMinMemory, parseErr := resource.ParseQuantity(templateSpec.MinMemory)
+			if parseErr != nil {
+				log.Error(parseErr, "Failed to parse MinMemory", "MinMemory", templateSpec.MinMemory)
+				return nil, fmt.Errorf("failed to parse MinMemory '%s': %w", templateSpec.MinMemory, parseErr)
+			}
+			if parsedMinMemory.Value() > 0 {
+				calculatedResources[corev1.ResourceMemory] = parsedMinMemory
+			} else {
+				log.Info("MinMemory is specified but parses to zero or less, requesting no Memory.", "MinMemory", templateSpec.MinMemory)
+			}
+		} else {
+			log.Info("Node has no allocatable Memory and no MinMemory specified, requesting no Memory.")
+		}
+	} else {
+		memoryPercentageValue := float64(memoryAllocatable.Value()) * (float64(templateSpec.MemoryPercentage) / 100.0)
+		calculatedMemory := resource.NewQuantity(int64(memoryPercentageValue), resource.BinarySI)
+
+		minMemoryQuantitySet := false
+		var minMemoryQuantity resource.Quantity
+		if templateSpec.MinMemory != "" {
+			var parseErr error
+			minMemoryQuantity, parseErr = resource.ParseQuantity(templateSpec.MinMemory)
+			if parseErr != nil {
+				log.Error(parseErr, "Failed to parse MinMemory", "MinMemory", templateSpec.MinMemory)
+				return nil, fmt.Errorf("failed to parse MinMemory '%s': %w", templateSpec.MinMemory, parseErr)
+			}
+			minMemoryQuantitySet = true
+		}
+
+		if minMemoryQuantitySet && calculatedMemory.Cmp(minMemoryQuantity) < 0 {
+			log.Info("Calculated Memory is less than MinMemory, using MinMemory", "calculatedMemory", calculatedMemory.String(), "minMemory", minMemoryQuantity.String())
+			calculatedMemory = &minMemoryQuantity
+		}
+
+		if calculatedMemory.Value() > 0 {
+		    calculatedResources[corev1.ResourceMemory] = *calculatedMemory
+		} else {
+			log.Info("Calculated Memory (after considering MinMemory if any) is zero or less. Requesting no Memory.", "finalCalculatedMemory", calculatedMemory.String())
+		}
+	}
+
+	// Calculate Ephemeral Storage
+	storageAllocatable, ok := nodeAllocatable[corev1.ResourceEphemeralStorage]
+	if !ok {
+		log.Info("Node has no allocatable EphemeralStorage information. Cannot calculate Storage percentage.")
+		if templateSpec.MinStorage != "" {
+			parsedMinStorage, parseErr := resource.ParseQuantity(templateSpec.MinStorage)
+			if parseErr != nil {
+				log.Error(parseErr, "Failed to parse MinStorage", "MinStorage", templateSpec.MinStorage)
+				return nil, fmt.Errorf("failed to parse MinStorage '%s': %w", templateSpec.MinStorage, parseErr)
+			}
+			if parsedMinStorage.Value() > 0 {
+				calculatedResources[corev1.ResourceEphemeralStorage] = parsedMinStorage
+			} else {
+				log.Info("MinStorage is specified but parses to zero or less, requesting no Storage.", "MinStorage", templateSpec.MinStorage)
+			}
+		} else {
+			log.Info("Node has no allocatable Storage and no MinStorage specified, requesting no Storage.")
+		}
+	} else {
+		storagePercentageValue := float64(storageAllocatable.Value()) * (float64(templateSpec.StoragePercentage) / 100.0)
+		calculatedStorage := resource.NewQuantity(int64(storagePercentageValue), resource.BinarySI)
+
+		minStorageQuantitySet := false
+		var minStorageQuantity resource.Quantity
+		if templateSpec.MinStorage != "" {
+			var parseErr error
+			minStorageQuantity, parseErr = resource.ParseQuantity(templateSpec.MinStorage)
+			if parseErr != nil {
+				log.Error(parseErr, "Failed to parse MinStorage", "MinStorage", templateSpec.MinStorage)
+				return nil, fmt.Errorf("failed to parse MinStorage '%s': %w", templateSpec.MinStorage, parseErr)
+			}
+			minStorageQuantitySet = true
+		}
+
+		if minStorageQuantitySet && calculatedStorage.Cmp(minStorageQuantity) < 0 {
+			log.Info("Calculated Storage is less than MinStorage, using MinStorage", "calculatedStorage", calculatedStorage.String(), "minStorage", minStorageQuantity.String())
+			calculatedStorage = &minStorageQuantity
+		}
+		
+		if calculatedStorage.Value() > 0 {
+		    calculatedResources[corev1.ResourceEphemeralStorage] = *calculatedStorage
+		} else {
+			log.Info("Calculated Storage (after considering MinStorage if any) is zero or less. Requesting no Storage.", "finalCalculatedStorage", calculatedStorage.String())
+		}
+	}
+	
+	log.Info("Calculated pod resources", "resources", calculatedResources.String())
+	return calculatedResources, nil
+}

--- a/pkg/webhook/mutator.go
+++ b/pkg/webhook/mutator.go
@@ -1,0 +1,180 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	flexdaemonsetsv1alpha1 "github.com/prakarsh-dt/FlexDaemonsets/pkg/apis/flexdaemonsets/v1alpha1"
+	"github.com/prakarsh-dt/FlexDaemonsets/pkg/utils" // Import the utils package
+)
+
+const (
+	FlexDaemonsetTemplateAnnotation = "flexdaemonsets.xai/resource-template"
+)
+
+var log = ctrl.Log.WithName("webhook").WithName("PodMutator")
+
+// PodMutator mutates Pods
+type PodMutator struct {
+	Client  client.Client
+	Decoder *admission.Decoder
+}
+
+// Handle is the main entry point for the mutating webhook.
+func (m *PodMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	pod := &corev1.Pod{}
+	err := m.Decoder.Decode(req, pod)
+	if err != nil {
+		log.Error(err, "Failed to decode pod from admission request")
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Create a logger specific to this request
+	requestLogger := log.WithValues(
+		"podUID", req.UID,
+		"podKind", req.Kind.Kind,
+		"podNamespace", req.Namespace,
+		"podName", req.Name, // req.Name should be populated for existing pods, use pod.GenerateName for new ones if empty
+		"operation", req.Operation,
+	)
+	if req.Name == "" && pod.GenerateName != "" { // More accurate logging for pods being created
+	    requestLogger = log.WithValues(
+		    "podUID", req.UID,
+		    "podKind", req.Kind.Kind,
+		    "podNamespace", req.Namespace,
+		    "podGenerateName", pod.GenerateName, 
+		    "operation", req.Operation,
+	    )
+    }
+
+
+	// Check if the pod is part of a DaemonSet.
+	isDaemonSetPod := false
+	for _, ownerRef := range pod.OwnerReferences {
+		if ownerRef.Kind == "DaemonSet" && ownerRef.APIVersion == "apps/v1" { // Be specific about DaemonSet API version
+			isDaemonSetPod = true
+			break
+		}
+	}
+
+	if !isDaemonSetPod {
+		requestLogger.Info("Pod is not owned by a DaemonSet, skipping mutation.")
+		return admission.Allowed("Pod is not owned by a DaemonSet.")
+	}
+	
+	requestLogger.Info("Pod is owned by a DaemonSet, checking for FlexDaemonset annotation.")
+
+	templateName, ok := pod.Annotations[FlexDaemonsetTemplateAnnotation]
+	if !ok {
+		requestLogger.Info("FlexDaemonset annotation not found, skipping mutation.", "annotation", FlexDaemonsetTemplateAnnotation)
+		return admission.Allowed("FlexDaemonset annotation not found.")
+	}
+
+	if templateName == "" {
+		requestLogger.Info("FlexDaemonset annotation value is empty, skipping mutation.", "annotation", FlexDaemonsetTemplateAnnotation)
+		return admission.Allowed("FlexDaemonset annotation value is empty.")
+	}
+
+	requestLogger.Info("FlexDaemonset annotation found.", "templateName", templateName)
+
+	// 1. Fetch the FlexDaemonsetTemplate CRD instance
+	template := &flexdaemonsetsv1alpha1.FlexDaemonsetTemplate{}
+	err = m.Client.Get(ctx, types.NamespacedName{Name: templateName}, template) // Cluster-scoped, so no namespace
+	if err != nil {
+		requestLogger.Error(err, "Failed to get FlexDaemonsetTemplate.", "templateName", templateName)
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to get FlexDaemonsetTemplate '%s': %w", templateName, err))
+	}
+	requestLogger.Info("Successfully fetched FlexDaemonsetTemplate.", "templateName", templateName)
+
+	// 2. Fetch the Node object where the pod is scheduled
+	if pod.Spec.NodeName == "" {
+		requestLogger.Info("Pod.Spec.NodeName is not set. Cannot determine node for resource allocation. Skipping mutation.")
+		return admission.Allowed("Pod NodeName not specified at time of mutation.")
+	}
+
+	node := &corev1.Node{}
+	err = m.Client.Get(ctx, types.NamespacedName{Name: pod.Spec.NodeName}, node)
+	if err != nil {
+		requestLogger.Error(err, "Failed to get Node.", "nodeName", pod.Spec.NodeName)
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to get Node '%s': %w", pod.Spec.NodeName, err))
+	}
+	requestLogger.Info("Successfully fetched Node.", "nodeName", node.Name, "allocatableCPU", node.Status.Allocatable.Cpu().String(), "allocatableMemory", node.Status.Allocatable.Memory().String())
+
+	// 3. Calculate desired resources
+	calculatedPodResources, err := utils.CalculatePodResources(&template.Spec, node.Status.Allocatable)
+	if err != nil {
+		requestLogger.Error(err, "Failed to calculate pod resources.")
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to calculate pod resources: %w", err))
+	}
+
+	if len(calculatedPodResources) == 0 {
+		requestLogger.Info("Calculated resources are empty (e.g. all percentages and minimums are zero). No mutation will be applied.")
+		return admission.Allowed("Calculated resources are empty, no changes.")
+	}
+	
+	requestLogger.Info("Successfully calculated pod resources.", "calculatedResources", calculatedPodResources.String())
+
+	// 4. Create JSON patch
+	mutatedPod := pod.DeepCopy() // It's crucial to copy the pod object before mutating it
+
+	// Apply calculated resources to all containers.
+	// For DaemonSets, typically all containers get the same resource allocation,
+	// or specific container names could be targeted if the CRD was extended.
+	for i := range mutatedPod.Spec.Containers {
+		if mutatedPod.Spec.Containers[i].Resources.Requests == nil {
+			mutatedPod.Spec.Containers[i].Resources.Requests = corev1.ResourceList{}
+		}
+		if mutatedPod.Spec.Containers[i].Resources.Limits == nil {
+			mutatedPod.Spec.Containers[i].Resources.Limits = corev1.ResourceList{}
+		}
+
+		for resourceName, quantity := range calculatedPodResources {
+			mutatedPod.Spec.Containers[i].Resources.Requests[resourceName] = quantity
+			mutatedPod.Spec.Containers[i].Resources.Limits[resourceName] = quantity // Setting limits equal to requests
+		}
+		requestLogger.Info("Applied resources to container.", "containerName", mutatedPod.Spec.Containers[i].Name, "resources", calculatedPodResources.String())
+	}
+	
+	// Also apply to init containers, if any
+	for i := range mutatedPod.Spec.InitContainers {
+		if mutatedPod.Spec.InitContainers[i].Resources.Requests == nil {
+			mutatedPod.Spec.InitContainers[i].Resources.Requests = corev1.ResourceList{}
+		}
+		if mutatedPod.Spec.InitContainers[i].Resources.Limits == nil {
+			mutatedPod.Spec.InitContainers[i].Resources.Limits = corev1.ResourceList{}
+		}
+
+		for resourceName, quantity := range calculatedPodResources {
+			mutatedPod.Spec.InitContainers[i].Resources.Requests[resourceName] = quantity
+			mutatedPod.Spec.InitContainers[i].Resources.Limits[resourceName] = quantity // Setting limits equal to requests
+		}
+		requestLogger.Info("Applied resources to init container.", "containerName", mutatedPod.Spec.InitContainers[i].Name, "resources", calculatedPodResources.String())
+	}
+
+
+	marshaledPod, err := json.Marshal(mutatedPod)
+	if err != nil {
+		requestLogger.Error(err, "Failed to marshal mutated pod.")
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	requestLogger.Info("Successfully mutated pod. Returning patch response.")
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
+}
+
+// InjectDecoder injects the decoder into the PodMutator.
+func (m *PodMutator) InjectDecoder(d *admission.Decoder) error {
+	m.Decoder = d
+	return nil
+}
+
+var _ admission.Handler = &PodMutator{}
+var _ admission.DecoderInjector = &PodMutator{}


### PR DESCRIPTION


I've implemented the core functionality for the FlexDaemonsets mutating webhook.

Key features completed:
- Defined the Custom Resource Definition (CRD) for FlexDaemonsetTemplate (this was pre-existing).
- Created a mutating webhook to intercept pod creation for annotated DaemonSets.
- Developed logic to retrieve FlexDaemonsetTemplate and Node resources.
- Implemented the calculation of resources based on percentages and minimums.
- Added functionality to modify pod specifications to inject calculated resources into containers.
- Set up an HTTPS server with TLS (certificates are managed via flags/secrets).
- Created Kubernetes manifests for Role-Based Access Control (RBAC), webhook configuration, deployment, and service.
- Provided a sample DaemonSet and FlexDaemonsetTemplate.
- Developed a comprehensive Makefile for building, deploying, and generating certificates.
- Integrated logging using controller-runtime's default logger.

The webhook now processes DaemonSet pods that have the 'flexdaemonsets.xai/resource-template' annotation. It dynamically adjusts resource requests and limits based on the referenced FlexDaemonsetTemplate and the capacity of the node.